### PR TITLE
flattol: use $0 instead of which flattool

### DIFF
--- a/flattool
+++ b/flattool
@@ -39,7 +39,7 @@ checkForNewVersion() {
     if ((currentTime - asLastUpdateCheck < 3600)); then
         return 2
     fi
-    sed -E -i "s/^asLastUpdateCheck=\"[0-9]{10}\"$/asLastUpdateCheck=\"${currentTime}\"/" "$(which flattool)"
+    sed -E -i "s/^asLastUpdateCheck=\"[0-9]{10}\"$/asLastUpdateCheck=\"${currentTime}\"/" "$0"
     latestRelease=$(curl -s "https://api.github.com/repos/$owner/$repo/releases/latest")
     latestTag=$(echo "$latestRelease" | grep -o '"tag_name": "[^"]*' | cut -d'"' -f4 | head -n1)
     if [ "$latestTag" = "$versionNumber" ]; then
@@ -339,7 +339,7 @@ fixOrphans() {
 # <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 
 if [ "$asFirstRun" == "true" ]; then
-    sed -i 's/^asFirstRun="true"$/asFirstRun="false"/' "$(which flattool)"
+    sed -i 's/^asFirstRun="true"$/asFirstRun="false"/' "$0"
     echo -e "Thank you for using flattool! This is the first time its being ran. Make sure to run 'flattool --help' if you are unsure of how to use this.\n"
     echo -e "flattool can check for updates, these checks will occur on every run, so long as it has been an hour since the last check."
     echo -e "To install an update, run 'flattool update-check'."
@@ -347,10 +347,10 @@ if [ "$asFirstRun" == "true" ]; then
     read -r answer
     case $answer in
         [Nn])
-            sed -i 's/^asAutoCheckUpdate="true"$/asAutoCheckUpdate="false"/' "$(which flattool)"
+            sed -i 's/^asAutoCheckUpdate="true"$/asAutoCheckUpdate="false"/' "$0"
             ;;
         *)
-            sed -i 's/^asAutoCheckUpdate="false"$/asAutoCheckUpdate="true"/' "$(which flattool)"
+            sed -i 's/^asAutoCheckUpdate="false"$/asAutoCheckUpdate="true"/' "$0"
             ;;
     esac
     
@@ -481,10 +481,10 @@ case "$subcommand" in
         ;;
     auto-update)
         if [ "$asAutoCheckUpdate" = "true" ]; then
-            sed -i 's/^asAutoCheckUpdate="true"$/asAutoCheckUpdate="false"/' "$(which flattool)"
+            sed -i 's/^asAutoCheckUpdate="true"$/asAutoCheckUpdate="false"/' "$0"
             echo "flattool will not check for updates on each run. To manually check, run 'flattool update-check'"
         else
-            sed -i 's/^asAutoCheckUpdate="false"$/asAutoCheckUpdate="true"/' "$(which flattool)"
+            sed -i 's/^asAutoCheckUpdate="false"$/asAutoCheckUpdate="true"/' "$0"
             echo "flattool will check for updates on each run."
         fi
         ;;
@@ -499,7 +499,7 @@ case "$subcommand" in
                 echo "New version of flattool is available: ${latestTag}"
                 userConsent "Do you want to install this new update?"
                 echo "Installing new version..."
-                wget -N -P "$(dirname "$(which flattool)")" "https://raw.githubusercontent.com/${owner}/${repo}/main/flattool"
+                wget -N -P "$(dirname "$0")" "https://raw.githubusercontent.com/${owner}/${repo}/main/flattool"
                 ;;
         esac
         exit 0


### PR DESCRIPTION
This change would allow users to not have flattool in PATH by using the $0 variable to retrieve the path to the shell script.